### PR TITLE
[Fix] 버그 리포트 메일을 예외 처리하여 오류를 해결 했습니다.

### DIFF
--- a/SettingView.swift
+++ b/SettingView.swift
@@ -27,7 +27,7 @@ struct SettingView: View {
                     label: {
                         Label {
                             Text("오류 및 문의 메일 보내기")
-                                .foregroundColor(.black)
+                                .foregroundColor(.primary)
                         } icon : {
                             Image(systemName: "ladybug.fill")
                         }

--- a/SettingView.swift
+++ b/SettingView.swift
@@ -12,14 +12,14 @@ struct SettingView: View {
     
     @State var result: Result<MFMailComposeResult, Error>? = nil
     @State var isShowingMailView = false
-    @State private var checkingUseMail: Bool = MFMailComposeViewController.canSendMail()
     
     var body: some View {
         Form {
             NavigationLink(destination: MyWebView(urlToLoad: "https://github.com/DeveloperAcademy-POSTECH/Hangleton_Team8_LightHouse/blob/b9aef33a6cdeb487b96159b678350dc171bd4fc8/License.md").navigationTitle("라이센스")) {
                 Label("라이센스", systemImage: "doc.on.clipboard.fill")//
             }
-            if checkingUseMail {
+            //하단 if문은 메일을 보낼 수 있는지 확인하는 코드입니다.
+            if MFMailComposeViewController.canSendMail() {
                 Button(
                     action: {
                         isShowingMailView.toggle()

--- a/SettingView.swift
+++ b/SettingView.swift
@@ -34,7 +34,7 @@ struct SettingView: View {
                     }
                 )
                 .sheet(isPresented: $isShowingMailView) {
-                    MailView(isShowing: self.$isShowingMailView, result: self.$result)
+                    MailView(isShowing: $isShowingMailView, result: $result)
                 }
             }
         }

--- a/SettingView.swift
+++ b/SettingView.swift
@@ -12,27 +12,30 @@ struct SettingView: View {
     
     @State var result: Result<MFMailComposeResult, Error>? = nil
     @State var isShowingMailView = false
-    
+    @State private var checkingUseMail: Bool = MFMailComposeViewController.canSendMail()
     
     var body: some View {
         Form {
             NavigationLink(destination: MyWebView(urlToLoad: "https://github.com/DeveloperAcademy-POSTECH/Hangleton_Team8_LightHouse/blob/b9aef33a6cdeb487b96159b678350dc171bd4fc8/License.md").navigationTitle("라이센스")) {
                 Label("라이센스", systemImage: "doc.on.clipboard.fill")//
             }
-            Button(
-                action: {
-                    isShowingMailView.toggle()                },
-                label: {
-                    Label {
-                        Text("오류 및 문의 메일 보내기")
-                            .foregroundColor(.black)
-                    } icon : {
-                        Image(systemName: "ladybug.fill")
+            if checkingUseMail {
+                Button(
+                    action: {
+                        isShowingMailView.toggle()
+                    },
+                    label: {
+                        Label {
+                            Text("오류 및 문의 메일 보내기")
+                                .foregroundColor(.black)
+                        } icon : {
+                            Image(systemName: "ladybug.fill")
+                        }
                     }
+                )
+                .sheet(isPresented: $isShowingMailView) {
+                    MailView(isShowing: self.$isShowingMailView, result: self.$result)
                 }
-            )
-            .sheet(isPresented: $isShowingMailView) {
-                MailView(isShowing: self.$isShowingMailView, result: self.$result)
             }
         }
         .navigationTitle("설정")

--- a/VoiceOver Dictionary/View/MainView.swift
+++ b/VoiceOver Dictionary/View/MainView.swift
@@ -64,11 +64,10 @@ struct MainView: View {
                 } label: {
                     HStack(alignment:.bottom,spacing: 1){
                         Image(systemName: "gearshape.fill")
-                            .foregroundColor(.black)
+                            .foregroundColor(.primary)
                             .accessibility(label: Text("설정"))
                     }
                 }
-
             }
             .searchable(text: $searchText)
         }


### PR DESCRIPTION
# 수정사항
기존 코드에서 버그리포트 화면에서
메일앱을 사용할 수 없는 사용자 가 버그 메일을 발송 하려 할 때 생기는 크래쉬를 수정했습니다.
-1. 시뮬레이터
-2. 메일앱을 사용하지 않는 유저

#이미지 파일

정상적으로 사용가능한 상태에서는 하단처럼 버그 리포트 화면이 뷰잉됩니다.
![IMG_70A4772BCAAD-1](https://user-images.githubusercontent.com/103024840/195070277-52b3eee6-1538-4876-9ddf-5353ef236136.jpeg)

시뮬레이터의 경우 사용할 수 없어서 해당 버튼이 보이지 않습니다.
![simulator_screenshot_7A8FA0CB-66A8-465C-89EF-24743A32F528](https://user-images.githubusercontent.com/103024840/195070432-651f7f06-0d1e-4129-8d42-4e50297b5258.png)

# 왜 이렇게 해결 했나요?
뎁스를 하나 추가해서 뷰를  꾸미고 전송 결과를 보여주거나
버튼을 눌렀을 때 사용가능, 불가능, 메일 발송 성공 결과를 팝업으로 보여줘도 좋지만
화면을 직접적으로 사용하기 어려운 사용자의 경우 
뎁스가 깊어지거나 알림창이 뜨는것이 불편 하다고 생각이 들어서 저렇게 처리 했습니다.